### PR TITLE
Cube IDE 1.9.0に対応

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,16 +1,18 @@
 FROM azul/zulu-openjdk:8u275
 
-COPY installer/en.st-stm32cubeide_1.5.1_9029_20201210_1234_amd64.sh.zip /usr/local/src/stm32cubeide/
+ARG ZIP_FILE_NAME=""
+ARG VERSION="0.0.0"
+COPY installer/$ZIP_FILE_NAME.zip /usr/local/src/stm32cubeide/
 RUN apt-get update && apt-get -y install build-essential sudo gcc-arm-none-eabi unzip libswt-gtk-4-jni && \
     cd /usr/local/src/stm32cubeide && \
-    unzip en.st-stm32cubeide_1.5.1_9029_20201210_1234_amd64.sh.zip && \
-    rm en.st-stm32cubeide_1.5.1_9029_20201210_1234_amd64.sh.zip && \
-    bash st-stm32cubeide_1.5.1_9029_20201210_1234_amd64.sh --noexec && \
-    cd makeself_dir_Y5O3Hx && \
+    unzip $ZIP_FILE_NAME.zip && \
+    rm $ZIP_FILE_NAME.zip && \
+    bash $(basename *.sh) --noexec && \
+    cd $(ls -d */ | head -1) && \
     echo "#!""/bin/bash" | tee prompt_linux_license.sh && \
     echo "exit 0" | tee -a prompt_linux_license.sh && \
     sed -i -e 's/segger.*\.sh//g' install_as_root.sh && \
-    ./setup.sh /opt/st/stm32cubeide_1.5.1 && \
+    ./setup.sh /opt/st/stm32cubeide_$VERSION && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/build-docker-image-gui.sh
+++ b/build-docker-image-gui.sh
@@ -3,6 +3,16 @@ set -eu
 
 SRC_DIR=$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)
 
+# build docker images
+cd ${SRC_DIR}/base
+# インストーラ（zipファイル）名を取得
+FILE_NAME=$(basename installer/*.zip .zip)
+if [ "$FILE_NAME" == "" ]; then
+  echo "ファイルが存在しません"
+  exit 0
+fi
+VERSION=${FILE_NAME: -5}
+
 # get parameter from system
 DOCKER_USER=${USER:-$(id -un)}
 DOCKER_GROUP=`id -gn`
@@ -16,4 +26,5 @@ docker build -t ${DOCKER_USER}/stm32cubeide-gui \
     --build-arg UID=${DOCKER_UID} \
     --build-arg GROUP=${DOCKER_GROUP} \
     --build-arg GID=${DOCKER_GID} \
+    --build-arg VERSION=${VERSION} \
     -f Dockerfile .

--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -5,4 +5,12 @@ SRC_DIR=$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)
 
 # build docker images
 cd ${SRC_DIR}/base
-docker build -t tiryoh/stm32cubeide:1.5.1 -f Dockerfile .
+# インストーラ（zipファイル）名を取得
+FILE_NAME=$(basename installer/*.zip .zip)
+if [ "$FILE_NAME" == "" ]; then
+  echo "ファイルが存在しません"
+  exit 0
+fi
+
+VERSION=${FILE_NAME: -5}
+docker build -t tiryoh/stm32cubeide:$VERSION -f Dockerfile . --build-arg ZIP_FILE_NAME=$FILE_NAME --build-arg VERSION=$VERSION

--- a/gui/Dockerfile
+++ b/gui/Dockerfile
@@ -1,4 +1,5 @@
-FROM tiryoh/stm32cubeide:1.5.1
+ARG VERSION=0.0.0
+FROM tiryoh/stm32cubeide:$VERSION
 
 # Arguments
 ARG USER=initial


### PR DESCRIPTION
STM32 Cube IDE 1.9.0のイメージを作るための変更です。

`installer`ディレクトリに置いたzipファイル名をもとにideのバージョンを特定し、
dockerイメージを作成します。

実行コマンドは`build-docker-image.sh`から変わっていません。

下記のバージョンでイメージが生成されることを確認しています。
- バージョン1.9.0（en.st-stm32cubeide_1.9.0_12015_20220302_0855_amd64.sh_v1.9.0.zip）
- バージョン1.5.1（en.st-stm32cubeide_1.5.1_9029_20201210_1234_amd64.sh_v1.5.1.zip）

## その他

バージョン1.9.0のイメージを使ってプロジェクトをビルドできることを確認しました。
バージョン1.5.1は`headless-build`の仕様が違うため、ビルドを確認できてません。

```sh
# stm32のプロジェクトへ移動（
$ cd /path/to/project

# 1.9.0でプロジェクトをビルドする
$ docker run -it --rm --volume `pwd`:/root/workspace/$(basename `pwd`) tiryoh/stm32cubeide:1.9.0 /opt/st/stm32cubeide_1.9.0/headless-build.sh -import /root/workspace/$(basename `pwd`) -cleanBuild $(basename `pwd`)
```


GUIアプリケーションの起動は確認していません。
